### PR TITLE
adding covariance matrix functions

### DIFF
--- a/src/qnetti/__init__.py
+++ b/src/qnetti/__init__.py
@@ -1,2 +1,3 @@
 from ._version import __version__
+from .covariance_matrices import *
 from .topology_inference import *

--- a/src/qnetti/covariance_matrices.py
+++ b/src/qnetti/covariance_matrices.py
@@ -1,0 +1,88 @@
+import numpy as np
+import pennylane as qml
+import qnetvo
+
+
+def qubit_covariance_matrix_fn(prep_node, dev_kwargs={}, qnode_kwargs={}):
+    """Generates a function that evaluates the covariance matrix for local
+    qubit measurements.
+
+    Each local qubit is measured in the :math:`z`-basis and is preced by an arbitrary
+    qubit rotation as defined in PennyLane, |rot_ref|_.
+    Using the joint probability distribution :math:`\{P(x_i)\}_i` constructed from the quantum circuit evaluation,
+    we can evaluate the **covariance matrix** of an :math:`n`-qubit system as
+
+    .. math::
+
+        \text{Cov}(\{P(x_i)\}_{i}) = \begin{pmatrix}
+            \text{Var}(x_1) &  \text{Cov}(x_1,x_2) & \dots &  \text{Cov}(x_1, x_n) \\
+            \text{Cov}(x_2, x_1) & \text{Var}(x_2) & \dots & \text{Cov}(x_2, x_n) \\
+            \vdots & &  \ddots & \vdots \\
+            \text{Cov}(x_n, x_1) & \dots & \text{Cov}(x_n, x_{n-1} & \text{Var}(x_1, x_n) \\
+        \end{pmatrix}
+    
+    where for two random variables :math:`x_i` and :math:`x_j`, the covariance is define
+    :math:`\text{Cov}(x_i,x_j) = \langle (x_i - \langle x_i \rangle) (x_j - \langle x_j \rangle) \rangle`
+    and the variance is defined :math:`\text{Var}(x_i) = \text{Cov}(x_i, x_i)`.
+    Note that the covariance matrix is symmetric because :math:`\text{Cov}(x_i, x_j) = \text{Cov}(x_j, x_i)`.
+
+    .. |rot_ref| replace:: ``qml.Rot()``
+    .. _rot_ref: https://pennylane.readthedocs.io/en/stable/code/api/pennylane.Rot.html?highlight=rot#pennylane.Rot
+
+    :param prep_node: A network node that prepares the quantum state to evaluate.
+    :type prep_node: qnetvo.PrepareNode
+
+    :param dev_kwargs: Keyword arguments passed to the PennyLane device constructor.
+    :type dev_kwargs: dict
+
+    :param qnode_kwargs: Keyword arguments passed to the PennyLane qnode constructor.
+    :type qnode_kwargs: dict
+
+    :returns: A function, ``covari
+    :rtype: function
+    
+    """
+    qubit_rot = lambda settings, wires: qml.Rot(*settings[:3], wires=wires)
+
+    meas_nodes = [
+        qnetvo.MeasureNode(1, 1, wires=[wire], quantum_fn=qubit_rot, num_settings=3)
+        for wire in prep_node.wires
+    ]
+
+    ansatz = qnetvo.NetworkAnsatz([prep_node], meas_nodes, dev_kwargs=dev_kwargs)
+    joint_probs = qnetvo.joint_probs_qnode(ansatz, **qnode_kwargs)
+
+    return lambda meas_settings: qml.math.cov_matrix(
+        joint_probs(meas_settings),
+        [qml.PauliZ(wire) for wire in prep_node.wires],
+        wires=qml.wires.Wires(prep_node.wires),
+    )
+
+
+def qubit_covariance_cost_fn(prep_node, dev_kwargs={}, qnode_kwargs={}):
+    """Constructs a cost function that, when minimized, yields the maximal
+    distance between the covariance matrix of the `prep_node` and the origin.
+
+    That is, :math:`\text{Cost}(\Theta) = -\text{Tr}[\text{Cov}(\{P(x_i|\vec{\theta}_i)\}_i)^T \text{Cov}(\{P(x_i)\}_i)^T]`
+    where the `meas_settings` are :math:`\Theta = (\vec{\theta}_i\in\mathbb{R^3)_{i=1}^n`.
+
+    :param prep_node: A network node that prepares the quantum state to evaluate.
+    :type prep_node: qnetvo.PrepareNode
+
+    :param dev_kwargs: Keyword arguments passed to the PennyLane device constructor.
+    :type dev_kwargs: dict
+
+    :param qnode_kwargs: Keyword arguments passed to the PennyLane qnode constructor.
+    :type qnode_kwargs: dict
+
+    :returns: A function evaluated as ``cost(*meas_settings)``
+    :rtype: function
+    """
+
+    cov_mat = qubit_covariance_matrix_fn(prep_node, dev_kwargs, qnode_kwargs)
+
+    def qubit_covariance_cost(*meas_settings):
+        mat = cov_mat(meas_settings)
+        return -np.trace(mat.T @ mat)
+
+    return qubit_covariance_cost

--- a/test/covariance_matrices_test.py
+++ b/test/covariance_matrices_test.py
@@ -1,0 +1,79 @@
+import pytest
+import numpy as np
+import pennylane as qml
+import qnetvo
+
+import qnetti
+
+
+class TestQubitCovarianceMatrixFn:
+    @pytest.mark.parametrize(
+        "num_wires, meas_settings, cov_mat_match",
+        [
+            (2, [0, 0, 0, 0, 0, 0], [[1, 1], [1, 1]]),
+            (2, [0, np.pi / 4, 0, 0, 0, 0], [[1, 1 / np.sqrt(2)], [1 / np.sqrt(2), 1]]),
+            (2, [0, np.pi / 2, 0, 0, 0, 0], [[1, 0], [0, 1]]),
+            (2, [0, np.pi / 2, 0, 0, np.pi / 2, 0], [[1, 1], [1, 1]]),
+            (2, [0, 0, 0, 0, np.pi, 0], [[1, -1], [-1, 1]]),
+            (3, [0, 0, 0, 0, 0, 0, 0, 0, 0], [[1, 1, 1], [1, 1, 1], [1, 1, 1]]),
+            (
+                3,
+                [0, np.pi / 4, 0, 0, 0, 0, 0, 0, 0],
+                [
+                    [1, 1 / np.sqrt(2), 1 / np.sqrt(2)],
+                    [1 / np.sqrt(2), 1, 1],
+                    [1 / np.sqrt(2), 1, 1],
+                ],
+            ),
+            (3, [0, np.pi / 2, 0, 0, 0, 0, 0, np.pi, 0], [[1, 0, 0], [0, 1, -1], [0, -1, 1]]),
+        ],
+    )
+    def test_qubit_covariance_matrix_ghz_state(self, num_wires, meas_settings, cov_mat_match):
+        prep_node = qnetvo.PrepareNode(
+            num_in=1, wires=range(num_wires), quantum_fn=qnetvo.ghz_state, num_settings=0
+        )
+        cov_mat_fn = qnetti.qubit_covariance_matrix_fn(prep_node)
+
+        assert np.allclose(cov_mat_fn(meas_settings), cov_mat_match)
+
+    def test_qubit_covariance_matrix_W_state(self):
+        def W_state(settings, wires):
+            phi = 2 * np.arccos(1 / np.sqrt(3))
+            qml.RY(phi, wires=wires[0])
+            qml.CRot(-2 * np.pi, np.pi / 2, 2 * np.pi, wires=wires[0:2])
+
+            qml.CNOT(wires=wires[1:3])
+            qml.CNOT(wires=wires[0:2])
+            qml.PauliX(wires=wires[0])
+
+        prep_node = qnetvo.PrepareNode(
+            num_in=1, wires=[0, 1, 2], quantum_fn=W_state, num_settings=0
+        )
+        cov_mat_fn = qnetti.qubit_covariance_matrix_fn(prep_node)
+
+        assert np.allclose(
+            cov_mat_fn(np.zeros(9)), np.array([[8, -4, -4], [-4, 8, -4], [-4, -4, 8]]) / 9
+        )
+
+
+class TestQubitCovarianceCostFn:
+    @pytest.mark.parametrize(
+        "num_wires, meas_settings, cost_match",
+        [
+            (2, [0, 0, 0, 0, 0, 0], -4),
+            (2, [0, np.pi / 4, 0, 0, 0, 0], -3),
+            (2, [0, np.pi / 2, 0, 0, 0, 0], -2),
+            (2, [0, np.pi / 2, 0, 0, np.pi / 2, 0], -4),
+            (2, [0, 0, 0, 0, np.pi, 0], -4),
+            (3, [0, 0, 0, 0, 0, 0, 0, 0, 0], -9),
+            (3, [0, np.pi / 4, 0, 0, 0, 0, 0, 0, 0], -7),
+            (3, [0, np.pi / 2, 0, 0, 0, 0, 0, np.pi, 0], -5),
+        ],
+    )
+    def test_qubit_covariance_cost_fn_ghz_state(self, num_wires, meas_settings, cost_match):
+        prep_node = qnetvo.PrepareNode(
+            num_in=1, wires=range(num_wires), quantum_fn=qnetvo.ghz_state, num_settings=0
+        )
+        cov_cost = qnetti.qubit_covariance_cost_fn(prep_node)
+
+        assert np.allclose(cov_cost(*meas_settings), cost_match)


### PR DESCRIPTION
Hey @dannychen0830,

I've implemented some functionality that can be used to investigate the covariance matrix-based approaches to network inference. I've added two functions, please code review!

1. `qubit_covariance_matrix_fn` calculates the covariance matrix for local qubit measurements. The qubit covariance matrix is similar to the qubit characteristic matrix, it just replaces von Neumann entropy and measured mutual information with variance and covariance respectively.
2. `qubit_covariance_cost_fn` can be used to maximize the distance between the covariance matrix and the origin. This cost function can be used to optimize the local qubit measurements for optimal network inference.

Overall, the trainability of the covariance matrix and its ability to infer qubit topology makes this approach competitive with the characteristic matrix approach. The reason is that the entire covariance matrix can be evaluated from a single joint probability distribution for all qubits. This may lead to significantly fewer shots being needed to optimize the covariance matrix than required to obtain the characteristic matrix. 

In the upcoming investigation, it will be important to compare the covariance matrix based approaches with the characteristic matrix, which may alter the main results/narrative of our paper to a small degree.

The code review can be done completely through GitHub's web interface. Let me know if you have and questions.